### PR TITLE
Add filtering to ReadOnlyActionPipe with safe replays.

### DIFF
--- a/janet/src/main/java/io/techery/janet/ActionPipe.java
+++ b/janet/src/main/java/io/techery/janet/ActionPipe.java
@@ -33,7 +33,7 @@ public final class ActionPipe<A> implements ReadActionPipe<A>, WriteActionPipe<A
         this.pipeline = pipelineFactory.call();
         this.cancelFunc = cancelFunc;
         this.defaultSubscribeOn = defaultSubscribeOn;
-        this.cachedPipelines = new CachedPipelines<A>(observe(), observeSuccess());
+        this.cachedPipelines = new CachedPipelines<A>(this);
     }
 
     /**

--- a/janet/src/main/java/io/techery/janet/ActionPipe.java
+++ b/janet/src/main/java/io/techery/janet/ActionPipe.java
@@ -66,7 +66,7 @@ public final class ActionPipe<A> implements ReadActionPipe<A>, WriteActionPipe<A
     }
 
     /**
-     * Clear cached action
+     * {@inheritDoc}
      */
     public void clearReplays() {
         cachedPipelines.clearReplays();
@@ -121,6 +121,16 @@ public final class ActionPipe<A> implements ReadActionPipe<A>, WriteActionPipe<A
      */
     public ReadOnlyActionPipe<A> toReadOnly() {
         return new ReadOnlyActionPipe<A>(this);
+    }
+
+    /**
+     * Returns a presentation of the ReadOnlyActionPipe with specific predicate
+     *
+     * @return {@linkplain ReadOnlyActionPipe}
+     * @see #toReadOnly()
+     */
+    public ReadOnlyActionPipe<A> filter(Func1<? super A, Boolean> predicate) {
+        return new ReadOnlyActionPipe<A>(this, predicate);
     }
 
     private static final class ActionSuccessOnlyTransformer<T> implements Observable.Transformer<ActionState<T>, T> {

--- a/janet/src/main/java/io/techery/janet/CachedPipelines.java
+++ b/janet/src/main/java/io/techery/janet/CachedPipelines.java
@@ -11,9 +11,9 @@ class CachedPipelines<A> implements Replays<A> {
     private ConnectableObservable<ActionState<A>> cachedPipeline;
     private ConnectableObservable<A> cachedSuccessPipeline;
 
-    CachedPipelines(Observable<ActionState<A>> source, Observable<A> sourceSuccess) {
-        this.source = source;
-        this.sourceSuccess = sourceSuccess;
+    CachedPipelines(ReadActionPipe<A> actionPipe) {
+        this.source = actionPipe.observe();
+        this.sourceSuccess = actionPipe.observeSuccess();
         createCachedPipeline();
         createCachedSuccessPipeline();
     }

--- a/janet/src/main/java/io/techery/janet/CachedPipelines.java
+++ b/janet/src/main/java/io/techery/janet/CachedPipelines.java
@@ -1,0 +1,45 @@
+package io.techery.janet;
+
+import rx.Observable;
+import rx.observables.ConnectableObservable;
+
+class CachedPipelines<A> implements Replays<A> {
+
+    private final Observable<ActionState<A>> source;
+    private final Observable<A> sourceSuccess;
+
+    private ConnectableObservable<ActionState<A>> cachedPipeline;
+    private ConnectableObservable<A> cachedSuccessPipeline;
+
+    CachedPipelines(Observable<ActionState<A>> source, Observable<A> sourceSuccess) {
+        this.source = source;
+        this.sourceSuccess = sourceSuccess;
+        createCachedPipeline();
+        createCachedSuccessPipeline();
+    }
+
+    private void createCachedPipeline() {
+        this.cachedPipeline = source
+                .replay(1);
+        this.cachedPipeline.connect();
+    }
+
+    private void createCachedSuccessPipeline() {
+        this.cachedSuccessPipeline = sourceSuccess
+                .replay(1);
+        this.cachedSuccessPipeline.connect();
+    }
+
+    @Override public Observable<ActionState<A>> observeWithReplay() {
+        return cachedPipeline;
+    }
+
+    @Override public Observable<A> observeSuccessWithReplay() {
+        return cachedSuccessPipeline;
+    }
+
+    @Override public void clearReplays() {
+        createCachedPipeline();
+        createCachedSuccessPipeline();
+    }
+}

--- a/janet/src/main/java/io/techery/janet/ReadActionPipe.java
+++ b/janet/src/main/java/io/techery/janet/ReadActionPipe.java
@@ -2,7 +2,7 @@ package io.techery.janet;
 
 import rx.Observable;
 
-public interface ReadActionPipe<A> {
+public interface ReadActionPipe<A> extends Replays<A> {
 
     /**
      * Observe all states of specified action type
@@ -10,24 +10,7 @@ public interface ReadActionPipe<A> {
     Observable<ActionState<A>> observe();
 
     /**
-     * Observe all states of specified action type with cache.
-     * Last action state will be emitted immediately after subscribe.
-     *
-     * @see Observable#replay(int)
-     */
-    Observable<ActionState<A>> observeWithReplay();
-
-    /**
      * Observe success action only, if you want to catch any exceptions, use {@link ActionPipe#observe()}
      */
     Observable<A> observeSuccess();
-
-    /**
-     * Observe action result with cache.
-     * Emmit the latest result, if exist, immediately after subscribe.
-     *
-     * @see Observable#replay(int)
-     * @see ActionPipe#observeSuccess()
-     */
-    Observable<A> observeSuccessWithReplay();
 }

--- a/janet/src/main/java/io/techery/janet/ReadOnlyActionPipe.java
+++ b/janet/src/main/java/io/techery/janet/ReadOnlyActionPipe.java
@@ -1,6 +1,8 @@
 package io.techery.janet;
 
 import rx.Observable;
+import rx.functions.Func1;
+import rx.internal.util.UtilityFunctions;
 
 /**
  * Read only type of {@linkplain ActionPipe}
@@ -8,36 +10,74 @@ import rx.Observable;
 public final class ReadOnlyActionPipe<A> implements ReadActionPipe<A> {
 
     private final ReadActionPipe<A> actionPipe;
+    private final Func1<? super A, Boolean> filter;
+
+    private final CachedPipelines<A> cachedPipelines;
 
     public ReadOnlyActionPipe(ReadActionPipe<A> actionPipe) {
+        this(actionPipe, UtilityFunctions.alwaysTrue());
+    }
+
+    public ReadOnlyActionPipe(ReadActionPipe<A> actionPipe, Func1<? super A, Boolean> filter) {
         this.actionPipe = actionPipe;
+        this.filter = filter;
+
+        cachedPipelines = new CachedPipelines<A>(observe(), observeSuccess());
     }
 
     /**
      * {@inheritDoc}
      */
     @Override public Observable<ActionState<A>> observe() {
-        return actionPipe.observe();
+        return actionPipe.observe()
+                .filter(new FilterStateDecorator<A>(filter));
     }
 
     /**
      * {@inheritDoc}
      */
     @Override public Observable<ActionState<A>> observeWithReplay() {
-        return actionPipe.observe();
+        return cachedPipelines.observeWithReplay();
     }
 
     /**
      * {@inheritDoc}
      */
     @Override public Observable<A> observeSuccess() {
-        return actionPipe.observeSuccess();
+        return actionPipe.observeSuccess()
+                .filter(filter);
     }
 
     /**
      * {@inheritDoc}
      */
     @Override public Observable<A> observeSuccessWithReplay() {
-        return actionPipe.observeSuccessWithReplay();
+        return cachedPipelines.observeSuccessWithReplay();
+    }
+
+    @Override public void clearReplays() {
+        cachedPipelines.clearReplays();
+    }
+
+    /**
+     * Returns a presentation of the ReadOnlyActionPipe with specific predicate
+     *
+     * @return {@linkplain ReadOnlyActionPipe}
+     */
+    public ReadOnlyActionPipe<A> filter(Func1<? super A, Boolean> predicate) {
+        return new ReadOnlyActionPipe<A>(this, predicate);
+    }
+
+    private static class FilterStateDecorator<A> implements Func1<ActionState<A>, Boolean> {
+
+        private final Func1<? super A, Boolean> filter;
+
+        private FilterStateDecorator(Func1<? super A, Boolean> filter) {
+            this.filter = filter;
+        }
+
+        @Override public Boolean call(ActionState<A> state) {
+            return filter.call(state.action);
+        }
     }
 }

--- a/janet/src/main/java/io/techery/janet/ReadOnlyActionPipe.java
+++ b/janet/src/main/java/io/techery/janet/ReadOnlyActionPipe.java
@@ -22,7 +22,7 @@ public final class ReadOnlyActionPipe<A> implements ReadActionPipe<A> {
         this.actionPipe = actionPipe;
         this.filter = filter;
 
-        cachedPipelines = new CachedPipelines<A>(observe(), observeSuccess());
+        cachedPipelines = new CachedPipelines<A>(this);
     }
 
     /**

--- a/janet/src/main/java/io/techery/janet/ReadOnlyActionPipe.java
+++ b/janet/src/main/java/io/techery/janet/ReadOnlyActionPipe.java
@@ -55,6 +55,9 @@ public final class ReadOnlyActionPipe<A> implements ReadActionPipe<A> {
         return cachedPipelines.observeSuccessWithReplay();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override public void clearReplays() {
         cachedPipelines.clearReplays();
     }

--- a/janet/src/main/java/io/techery/janet/Replays.java
+++ b/janet/src/main/java/io/techery/janet/Replays.java
@@ -1,0 +1,28 @@
+package io.techery.janet;
+
+import rx.Observable;
+
+interface Replays<A> {
+    /**
+     * Observe all states of specified action type with cache.
+     * Last action state will be emitted immediately after subscribe.
+     *
+     * @see Observable#replay(int)
+     */
+    Observable<ActionState<A>> observeWithReplay();
+
+
+    /**
+     * Observe action result with cache.
+     * Emmit the latest result, if exist, immediately after subscribe.
+     *
+     * @see Observable#replay(int)
+     * @see ActionPipe#observeSuccess()
+     */
+    Observable<A> observeSuccessWithReplay();
+
+    /**
+     * Clear cached action
+     */
+    void clearReplays();
+}


### PR DESCRIPTION
Example,

`actionPipe.toReadOnly().filter(...).filter(...)`

and every lifted pipes will be with own cached replays