### PR TITLE
Don't create new pipelines on `Replays#clearReplays` at `CachedPipelines`

### DIFF
--- a/janet/src/main/java/io/techery/janet/CachedPipelines.java
+++ b/janet/src/main/java/io/techery/janet/CachedPipelines.java
@@ -1,7 +1,9 @@
 package io.techery.janet;
 
 import rx.Observable;
+import rx.functions.Func1;
 import rx.observables.ConnectableObservable;
+import rx.subjects.PublishSubject;
 
 class CachedPipelines<A> implements Replays<A> {
 
@@ -11,35 +13,56 @@ class CachedPipelines<A> implements Replays<A> {
     private ConnectableObservable<ActionState<A>> cachedPipeline;
     private ConnectableObservable<A> cachedSuccessPipeline;
 
+    private final PublishSubject clearingStream;
+
     CachedPipelines(ReadActionPipe<A> actionPipe) {
         this.source = actionPipe.observe();
         this.sourceSuccess = actionPipe.observeSuccess();
+        this.clearingStream = PublishSubject.create();
         createCachedPipeline();
         createCachedSuccessPipeline();
     }
 
     private void createCachedPipeline() {
-        this.cachedPipeline = source
-                .replay(1);
+        this.cachedPipeline = createPipeline(source);
         this.cachedPipeline.connect();
     }
 
     private void createCachedSuccessPipeline() {
-        this.cachedSuccessPipeline = sourceSuccess
-                .replay(1);
+        this.cachedSuccessPipeline = createPipeline(sourceSuccess);
         this.cachedSuccessPipeline.connect();
     }
 
+    private <A> ConnectableObservable<A> createPipeline(Observable<A> source) {
+        return source.concatWith(clearingStream).replay(1);
+    }
+
     @Override public Observable<ActionState<A>> observeWithReplay() {
-        return cachedPipeline;
+        return cachedPipeline.compose(NullFilter.<ActionState<A>>instance());
     }
 
     @Override public Observable<A> observeSuccessWithReplay() {
-        return cachedSuccessPipeline;
+        return  cachedSuccessPipeline.compose(NullFilter.<A>instance());
     }
 
     @Override public void clearReplays() {
-        createCachedPipeline();
-        createCachedSuccessPipeline();
+        clearingStream.onNext(null);
+    }
+
+    private static class NullFilter<T> implements Observable.Transformer<T, T> {
+
+        private static final NullFilter INSTANCE = new NullFilter();
+
+        public static <T> NullFilter<T> instance() {
+            return (NullFilter<T>) INSTANCE;
+        }
+
+        @Override public Observable<T> call(Observable<T> source) {
+            return source.filter(new Func1<Object, Boolean>() {
+                @Override public Boolean call(Object obj) {
+                    return obj != null;
+                }
+            });
+        }
     }
 }


### PR DESCRIPTION
Use clearing stream with null checker for subscribers instead. This allows to avoid mem. leaks for cached pipelines which stay connected to source even after `clearReplays` is called.