### PR TITLE
Rename method ActionPipe#createObservableSuccess to **Result

### DIFF
--- a/janet/src/main/java/io/techery/janet/ActionPipe.java
+++ b/janet/src/main/java/io/techery/janet/ActionPipe.java
@@ -110,7 +110,7 @@ public final class ActionPipe<A> implements ReadActionPipe<A>, WriteActionPipe<A
     }
 
     /** {@inheritDoc} */
-    @Override public Observable<A> createObservableSuccess(A action) {
+    @Override public Observable<A> createObservableResult(A action) {
         return createObservable(action).compose(new ActionStateToActionTransformer<A>());
     }
 

--- a/janet/src/main/java/io/techery/janet/WriteActionPipe.java
+++ b/janet/src/main/java/io/techery/janet/WriteActionPipe.java
@@ -49,5 +49,5 @@ public interface WriteActionPipe<A> {
      *
      * @param action prepared action to send
      */
-    Observable<A> createObservableSuccess(A action);
+    Observable<A> createObservableResult(A action);
 }

--- a/janet/src/test/java/io/techery/janet/TestPipeOperations.java
+++ b/janet/src/test/java/io/techery/janet/TestPipeOperations.java
@@ -48,7 +48,7 @@ public class TestPipeOperations extends BaseTest {
     public void createObservableSuccess() {
         TestSubscriber<TestAction> subscriber = new TestSubscriber<TestAction>();
         TestAction action = new TestAction();
-        actionPipe.createObservableSuccess(action).subscribe(subscriber);
+        actionPipe.createObservableResult(action).subscribe(subscriber);
         AssertUtil.assertSubscriberWithSingleValue(subscriber);
         subscriber.assertValue(action);
     }


### PR DESCRIPTION
It's more clear name for this method's role.